### PR TITLE
remove laravel_octane=0 environment variable

### DIFF
--- a/php-base/config/supervisor/conf.d/php-fpm.conf
+++ b/php-base/config/supervisor/conf.d/php-fpm.conf
@@ -9,6 +9,3 @@ stderr_logfile_maxbytes=0
 autorestart=false
 startretries=0
 stopasgroup=true
-
-; Let app know it's NOT running via octane
-environment=LARAVEL_OCTANE="0"


### PR DESCRIPTION
Some packages use this logic to verify it's running using octane:
```php
protected static function runningWithinOctane($app)
{
    return isset($_SERVER['LARAVEL_OCTANE']);
}
```

Which will always return true when we set it to 0:
`environment=LARAVEL_OCTANE="0"`