### PR TITLE
PHP - remove sleep from queue:work command

### DIFF
--- a/php-base/scripts/docker-entrypoint.sh
+++ b/php-base/scripts/docker-entrypoint.sh
@@ -36,7 +36,7 @@ elif [ "$1" = 'scheduler' ]; then
 # Helper to run queue jobs
 elif [ "$1" = 'queue' ]; then 
   shift 1;
-  exec php artisan queue:work --verbose --tries=3 --timeout=60 --rest=0.5 --sleep=3 --max-jobs=1000 --max-time=3600  "$@"
+  exec php artisan queue:work --verbose --tries=3 --timeout=60 --max-jobs=1000 --max-time=3600  "$@"
 
 # Init script, for use in initContainers (for example)
 elif [ "$1" = 'init' ]; then 


### PR DESCRIPTION
Since we have limits on CPU usage in the kubernetes config, I don't think a sleep property is necessary 