### PR TITLE
ENV-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@ This is a collection of Docker images, both for development purposes, use during
 # Development
 
 Changes to this repository will trigger a build and push to GitHub packages automatically.
+
+# Configuration
+
+## nginx
+
+Images with `nginx` can be configured using the following environment variables.
+
+### Robots
+
+| Environment Key | Applied | Description | Default |
+------------------|---------|------------------------
+| NGINX_ROBOTS_TAG | Every run | `X-Robots-Tag` value | `none` |
+| NGINX_ROBOTS_TXT | Every run | Content of `robots.txt` | `Disallow: /` |

--- a/common/config/nginx/site-mods-available.d/no-robots.conf
+++ b/common/config/nginx/site-mods-available.d/no-robots.conf
@@ -1,2 +1,0 @@
-# Disable crawlers
-add_header 'X-Robots-Tag' 'none';

--- a/common/config/nginx/site-mods-enabled.d/no-robots.conf
+++ b/common/config/nginx/site-mods-enabled.d/no-robots.conf
@@ -1,1 +1,0 @@
-../site-mods-available.d/no-robots.conf

--- a/common/scripts/startup/env-configure-robots.sh
+++ b/common/scripts/startup/env-configure-robots.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# Configure nginx robots rules based on ENV vars
+#
+# Inputs:
+# - NGINX_ROBOTS_TAG: defaults to 'none'
+# - NGINX_ROBOTS_TXT: defaults to 'Disallow: /'
+
+# Set defaults
+NGINX_ROBOTS_TAG="${NGINX_ROBOTS_TAG:-none}"
+NGINX_ROBOTS_TXT="${NGINX_ROBOTS_TXT:-Disallow: /}"
+
+if [ -d /etc/nginx/site-mods-enabled.d/ ]; then
+  # robots tag header
+  echo "Nginx: configuring robots tag header with '${NGINX_ROBOTS_TAG}'…"
+  cat <<EOF > /etc/nginx/site-mods-enabled.d/generated-robots.conf
+# Configure indexing
+add_header 'X-Robots-Tag' '${NGINX_ROBOTS_TAG}';
+EOF
+
+  # robots.txt file
+  echo "Nginx: configuring robots.txt with '${NGINX_ROBOTS_TXT}'…"
+  cat <<EOF >> /etc/nginx/site-mods-enabled.d/generated-robots.conf
+# Configure crawlers
+location = /robots.txt {
+  add_header 'Content-Type' 'text/plain';
+  return 200 "User-agent: *\n${NGINX_ROBOTS_TXT}\n";
+}
+EOF
+fi

--- a/matomo/Dockerfile
+++ b/matomo/Dockerfile
@@ -15,7 +15,7 @@ COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 COPY matomo/config/supervisor/conf.d/ /etc/supervisor/conf.d/
 # - init
-COPY matomo/scripts/ /scripts/
+COPY common/scripts/ matomo/scripts/ /scripts/
 
 # Configure cron
 RUN echo "*/30 * * * * /usr/local/bin/php /var/www/html/console core:archive --verbose --no-interaction" > /etc/crontabs/www-data

--- a/matomo/Dockerfile
+++ b/matomo/Dockerfile
@@ -15,7 +15,7 @@ COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 COPY matomo/config/supervisor/conf.d/ /etc/supervisor/conf.d/
 # - init
-COPY matomo/scripts/ /
+COPY matomo/scripts/ /scripts/
 
 # Configure cron
 RUN echo "*/30 * * * * /usr/local/bin/php /var/www/html/console core:archive --verbose --no-interaction" > /etc/crontabs/www-data
@@ -25,5 +25,5 @@ WORKDIR /var/www/html
 EXPOSE 8080
 
 # Start supervisord by default
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
 CMD ["serve"]

--- a/matomo/README.md
+++ b/matomo/README.md
@@ -20,6 +20,8 @@ Serves content on port `8080`.
 
 ## Configuration
 
+Check the [general readme](../README.md) for configuring common settings.
+
 This image can be configured using the following environment variables:
 
 | Environment Key | Applied | Description |

--- a/matomo/README.md
+++ b/matomo/README.md
@@ -14,6 +14,10 @@ Docker will default to the `serve` command.
 - `init`: initialize the project, such as executing migrations.
 - fallback: execute the provided command.
 
+## Info
+
+Serves content on port `8080`.
+
 ## Configuration
 
 This image can be configured using the following environment variables:
@@ -37,10 +41,6 @@ This image can be configured using the following environment variables:
 | MATOMO_DATABASE_NAME | Every run | Database name |
 | MATOMO_DATABASE_USER | Every run | Database user |
 | MATOMO_DATABASE_PASSWORD | Every run | Database password |
-
-## Info
-
-Serves content on port `8080`.
 
 # Initialization
 

--- a/matomo/scripts/docker-entrypoint.sh
+++ b/matomo/scripts/docker-entrypoint.sh
@@ -2,17 +2,13 @@
 
 set -euo pipefail
 
-
 ## Bootstrap
 
-
-if [ ! -e matomo.php ]; then
-  tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
-fi
-
+for script in /scripts/startup/*.sh; do
+  $script
+done
 
 ## Commands ##
-
 
 # Helper to serve all services
 if [ "$1" = 'serve' ]; then
@@ -20,7 +16,7 @@ if [ "$1" = 'serve' ]; then
 
 # Init script, for use in initContainers (for example)
 elif [ "$1" = 'init' ]; then 
-  exec /bootstrap.sh
+  exec /scripts/bootstrap.sh
 
 # Fallback: just execute given command
 else

--- a/matomo/scripts/startup/unzip-matomo.sh
+++ b/matomo/scripts/startup/unzip-matomo.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+if [ ! -e matomo.php ]; then
+  tar cf - --one-file-system -C /usr/src/matomo . | tar xf -
+fi

--- a/nuxt-base/Dockerfile
+++ b/nuxt-base/Dockerfile
@@ -20,16 +20,16 @@ COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 COPY nuxt-base/config/supervisor/conf.d/ /etc/supervisor/conf.d/
 # - init
-COPY nuxt-base/scripts/docker-entrypoint.sh /
+COPY nuxt-base/scripts/ /scripts/
 
 # Clean Up
 WORKDIR /app/www
-RUN chown -R nobody:nobody /docker-entrypoint.sh /app/www /run /var/lib/nginx /var/log/nginx \
+RUN chown -R nobody:nobody /scripts /app/www /run /var/lib/nginx /var/log/nginx \
   && addgroup nobody tty
 EXPOSE 8080
 
 # Start supervisord by default
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
 CMD ["serve"]
 
 #

--- a/nuxt-base/Dockerfile
+++ b/nuxt-base/Dockerfile
@@ -20,7 +20,7 @@ COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 COPY nuxt-base/config/supervisor/conf.d/ /etc/supervisor/conf.d/
 # - init
-COPY nuxt-base/scripts/ /scripts/
+COPY common/scripts/ nuxt-base/scripts/ /scripts/
 
 # Clean Up
 WORKDIR /app/www

--- a/nuxt-base/README.md
+++ b/nuxt-base/README.md
@@ -16,3 +16,7 @@ Docker will default to the `serve` command.
 ## Info
 
 Serves content on port `8080`.
+
+## Configuration
+
+Check the [general readme](../README.md) for configuring common settings.

--- a/nuxt-base/scripts/docker-entrypoint.sh
+++ b/nuxt-base/scripts/docker-entrypoint.sh
@@ -2,9 +2,13 @@
 
 set -euo pipefail
 
+## Bootstrap
+
+for script in /scripts/startup/*.sh; do
+  $script
+done
 
 ## Commands ##
-
 
 # Helper to serve all services
 if [ "$1" = 'serve' ]; then

--- a/php-base/Dockerfile
+++ b/php-base/Dockerfile
@@ -55,16 +55,16 @@ COPY php-base/config/php/ /etc/php${PHP_VERSION}/
 COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 # - init
-COPY php-base/scripts/docker-entrypoint.sh /
+COPY php-base/scripts/ /scripts/
 
 # Clean Up
 WORKDIR /app/www
-RUN chown -R nobody:nobody /docker-entrypoint.sh /app/www /run /var/lib/nginx /var/log/nginx /etc/nginx/site-mods-available.d/max-upload.conf /etc/php${PHP_VERSION}/php-fpm.d/www.conf \
+RUN chown -R nobody:nobody /scripts /app/www /run /var/lib/nginx /var/log/nginx /etc/nginx/site-mods-available.d/max-upload.conf /etc/php${PHP_VERSION}/php-fpm.d/www.conf \
   && addgroup nobody tty
 EXPOSE 8080
 
 # Start supervisord by default
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
 CMD ["serve"]
 
 #

--- a/php-base/Dockerfile
+++ b/php-base/Dockerfile
@@ -55,7 +55,7 @@ COPY php-base/config/php/ /etc/php${PHP_VERSION}/
 COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 # - init
-COPY php-base/scripts/ /scripts/
+COPY common/scripts/ php-base/scripts/ /scripts/
 
 # Clean Up
 WORKDIR /app/www

--- a/php-base/README.md
+++ b/php-base/README.md
@@ -25,6 +25,10 @@ Serves content on port `8080`.
 
 ## Configuration
 
-You can configure the max. allowed uploads via these 2 variables:
-- `SERVER_POST_MAX_SIZE`: max post size (in nginx and PHP)
-- `SERVER_POST_MAX_FILESIZE`: max upload file size (in PHP)
+This image can be configured using the following environment variables:
+
+| Environment Key | Applied | Description | Default |
+------------------|---------|------------------------
+| NGINX_MAX_BODY_SIZE | Every run | nginx: maximum client body size | `8M` |
+| PHP_POST_MAX_SIZE | Every run | PHP: maximum post size, should match nginx | `8M` |
+| PHP_POST_MAX_FILESIZE | Every run | PHP: maximum post file size | `2M` |

--- a/php-base/README.md
+++ b/php-base/README.md
@@ -25,6 +25,8 @@ Serves content on port `8080`.
 
 ## Configuration
 
+Check the [general readme](../README.md) for configuring common settings.
+
 This image can be configured using the following environment variables:
 
 | Environment Key | Applied | Description | Default |

--- a/php-base/scripts/docker-entrypoint.sh
+++ b/php-base/scripts/docker-entrypoint.sh
@@ -2,25 +2,13 @@
 
 set -euo pipefail
 
-
 ## Bootstrap
 
-
-# Apply max post envs
-echo "client_max_body_size ${SERVER_POST_MAX_SIZE:-8M};" > /etc/nginx/site-mods-available.d/max-upload.conf
-for php_config_file in /etc/php*/php-fpm.d/www.conf; do
-  echo "php_admin_value[post_max_size] = ${SERVER_POST_MAX_SIZE:-8M}" >> "$php_config_file"
-  echo "php_admin_value[upload_max_filesize] = ${SERVER_POST_MAX_FILESIZE:-2M}" >> "$php_config_file"
+for script in /scripts/startup/*.sh; do
+  $script
 done
 
-# Cache laravel config
-if [ -f '/app/www/artisan' ]; then
-  php artisan config:cache
-fi
-
-
 ## Commands ##
-
 
 # Helper to serve all services
 if [ "$1" = 'serve' ]; then

--- a/php-base/scripts/startup/cache-laravel-config.sh
+++ b/php-base/scripts/startup/cache-laravel-config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# Cache laravel config
+if [ -f '/app/www/artisan' ]; then
+  php artisan config:cache
+fi

--- a/php-base/scripts/startup/env-configure-upload-limit.sh
+++ b/php-base/scripts/startup/env-configure-upload-limit.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# Configure nginx & PHP upload limits based on ENV vars
+#
+# Inputs:
+# - NGINX_MAX_BODY_SIZE: defaults to '8M'
+# - PHP_POST_MAX_SIZE: defaults to $NGINX_MAX_BODY_SIZE (should match that value)
+# - PHP_POST_MAX_FILESIZE: defaults to '2M'
+
+# Set defaults
+NGINX_MAX_BODY_SIZE="${NGINX_MAX_BODY_SIZE:-8M}"
+PHP_POST_MAX_SIZE="${PHP_POST_MAX_SIZE:-$NGINX_MAX_BODY_SIZE}"
+PHP_POST_MAX_FILESIZE="${PHP_POST_MAX_FILESIZE:-2M}"
+
+if [ -d /etc/nginx/site-mods-enabled.d/ ]; then
+  # nginx body size
+  echo "Nginx: configuring max body size with '${NGINX_MAX_BODY_SIZE}'…"
+  cat <<EOF > /etc/nginx/site-mods-enabled.d/generated-max-upload.conf
+client_max_body_size ${NGINX_MAX_BODY_SIZE};
+EOF
+fi
+
+for php_config_file in /etc/php*/php-fpm.d/www.conf; do
+  # PHP upload limits
+  echo "PHP: configuring max upload with '${PHP_POST_MAX_SIZE}'…"
+  cat <<EOF >> "$php_config_file"
+php_admin_value[post_max_size] = ${PHP_POST_MAX_SIZE}
+EOF
+  echo "PHP: configuring max file upload with '${PHP_POST_MAX_FILESIZE}'…"
+  cat <<EOF >> "$php_config_file"
+php_admin_value[upload_max_filesize] = ${PHP_POST_MAX_FILESIZE}
+EOF
+done

--- a/web-base/Dockerfile
+++ b/web-base/Dockerfile
@@ -31,7 +31,7 @@ RUN rm -f /etc/nginx/conf.d/default.conf
 COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 # - init
-COPY web-base/scripts/ /scripts/
+COPY common/scripts/ web-base/scripts/ /scripts/
 COPY --from=build /app/import-meta-env /usr/bin/import-meta-env
 
 # Clean Up

--- a/web-base/Dockerfile
+++ b/web-base/Dockerfile
@@ -31,7 +31,7 @@ RUN rm -f /etc/nginx/conf.d/default.conf
 COPY common/config/supervisor/supervisord.conf /etc/supervisor/
 COPY common/config/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/
 # - init
-COPY web-base/scripts/docker-entrypoint.sh /
+COPY web-base/scripts/ /scripts/
 COPY --from=build /app/import-meta-env /usr/bin/import-meta-env
 
 # Clean Up
@@ -39,7 +39,7 @@ WORKDIR /app/www
 EXPOSE 80
 
 # Start supervisord by default
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
 CMD ["serve"]
 
 #

--- a/web-base/README.md
+++ b/web-base/README.md
@@ -17,6 +17,10 @@ Docker will default to the `serve` command.
 
 Serves content on port `80`.
 
+## Configuration
+
+Check the [general readme](../README.md) for configuring common settings.
+
 # Environment Injection
 
 :exclamation: Note that, if available, it will execute the `import-meta-env` command. This relies on a few things:

--- a/web-base/scripts/docker-entrypoint.sh
+++ b/web-base/scripts/docker-entrypoint.sh
@@ -2,25 +2,13 @@
 
 set -euo pipefail
 
-
 ## Bootstrap
 
-
-# Inject environment variables
-ENV_EXAMPLE_PATH=/etc/import-meta-env/example
-if [ -f $ENV_EXAMPLE_PATH ]; then
-  echo "Found example env at '$ENV_EXAMPLE_PATH', applying to codebase…"
-  import-meta-env \
-    --example $ENV_EXAMPLE_PATH \
-    --path '/app/www/index.html' \
-    --disposable || exit 1
-else
-  echo 'No example env file found, skipping env import…'
-fi
-
+for script in /scripts/startup/*.sh; do
+  $script
+done
 
 ## Commands ##
-
 
 # Helper to serve all services
 if [ "$1" = 'serve' ]; then

--- a/web-base/scripts/startup/inject-env-into-index.sh
+++ b/web-base/scripts/startup/inject-env-into-index.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# Inject environment variables
+ENV_EXAMPLE_PATH=/etc/import-meta-env/example
+if [ -f $ENV_EXAMPLE_PATH ]; then
+  echo "Found example env at '$ENV_EXAMPLE_PATH', applying to codebase…"
+  import-meta-env \
+    --example $ENV_EXAMPLE_PATH \
+    --path '/app/www/index.html' \
+    --disposable || exit 1
+else
+  echo 'No example env file found, skipping env import…'
+fi


### PR DESCRIPTION
Rework some systems to allow for ENV based configuration:
- Robots (header & txt)

The provided defaults are equivalent to the current "secure" setup. Values for easy "allow everything" (choose what you need):
```bash
NGINX_ROBOTS_TAG=all
NGINX_ROBOTS_TXT=Allow /
```

Note: if setting the CSP to mode `report-only`, you should configure the `NGINX_CSP_REPORT_URI` to point to a Sentry project.

⚠️ Tiny breaking change because the fixed `no-robots.conf` will disappear. We'll need to update the config & Dockerfile for the affected repositories ([there are a few](https://github.com/search?q=org%3Awisemen-digital%20robots.conf+language%3ADockerfile&type=code)).