### PR TITLE
ENG-3256 - Feature/database backups scaleway

### DIFF
--- a/.github/workflows/build-and-publish-database-backup.yml
+++ b/.github/workflows/build-and-publish-database-backup.yml
@@ -1,0 +1,35 @@
+---
+name: Build & Publish Database Backup
+
+on:
+  pull_request:
+    paths: &watch_paths
+      - '.github/actions/**'
+      - '.github/workflows/build-and-publish-database-backup.yml'
+      - '.github/workflows/internal-build-test-and-publish.yml'
+      - 'common/**'
+      - 'database-backup/**'
+  push:
+    branches:
+      - main
+    paths: *watch_paths
+  schedule:
+    - cron: "0 0 1,15 * *"  # Every 2 weeks
+  workflow_dispatch:
+
+jobs:
+  build-test-and-publish:
+    uses: ./.github/workflows/internal-build-test-and-publish.yml
+    strategy:
+      matrix:
+        version:
+          - alpine: '3.23'
+            name: lts
+            scw: '2.52'
+    with:
+      image: database-backup
+      version: ${{ matrix.version.name }}
+      run-tests: false
+      build-args: |
+        ALPINE_VERSION=${{ matrix.version.alpine }}
+        SCW_VERSION=${{ matrix.version.scw }}

--- a/database-backup/.dockerignore
+++ b/database-backup/.dockerignore
@@ -1,0 +1,14 @@
+# General
+**/.DS_Store
+**/*.md
+**/LICENSE
+
+# Git
+**/.git
+**/.github
+**/.gitattributes
+**/.gitignore
+
+# Docker
+**/.dockerignore
+**/Dockerfile

--- a/database-backup/Dockerfile
+++ b/database-backup/Dockerfile
@@ -1,0 +1,37 @@
+ARG ALPINE_VERSION="3.23"
+ARG SCW_VERSION="2.49"
+
+#
+# --- Stage 1: Tools ---
+#
+
+FROM scaleway/cli:${SCW_VERSION} AS scaleway
+
+#
+# --- Stage 2: Base ---
+#
+
+FROM common:${ALPINE_VERSION} AS base
+
+# Install packages
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+    curl \
+    openssh-client \
+    rclone
+
+# Install tools
+COPY --from=scaleway /scw /usr/local/bin/scw
+
+# Copy configuration files
+# - init
+COPY scripts/ /scripts/
+
+#
+# --- Variant: Default ---
+#
+
+FROM base AS final
+
+# Set default command
+CMD ["backup"]

--- a/database-backup/README.md
+++ b/database-backup/README.md
@@ -1,0 +1,110 @@
+# Database Backup
+
+🐳 A Docker image for automated database backups from Managed Databases to S3-compatible storage.
+
+Available images:
+- `latest`: normal version.
+
+## Commands
+
+This image supports multiple commands:
+
+- `backup`: creates backups of managed DBs (PostgreSQL, MySQL) and uploads them to any S3-compatible storage (Scaleway Object Storage, AWS S3, MinIO, etc.)
+- fallback: execute the provided command.
+
+## Configuration
+
+Configuration is done using environment variables, and may depend on the command.
+
+### Command `backup`
+
+You'll need to select a DB provider, and also:
+- Provider-specific configuration, see below for example for [Provider scw](#provider-scw).
+- Configure [general S3 remote](#general-s3-remote).
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DB_PROVIDER` | Hosting provider (i.e. `scw`) | Yes |
+| `DB_INSTANCE_ID` | Database instance ID | Yes |
+| `DB_NAME` | Name of the database to backup | Yes |
+
+### Provider `scw`
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `SCW_ACCESS_KEY` | Scaleway API access key | Yes |
+| `SCW_SECRET_KEY` | Scaleway API secret key | Yes |
+| `SCW_DEFAULT_ORGANIZATION_ID` | Scaleway organization ID | Yes |
+| `SCW_DEFAULT_PROJECT_ID` | Scaleway project ID | Yes |
+| `SCW_DEFAULT_REGION` | Scaleway region (e.g., `nl-ams`, `fr-par`) | Yes |
+
+### General S3 Remote
+
+Will be used by `rclone` to address a S3-bucket as a remote.
+
+| Variable | Description | Required | Example |
+|----------|-------------|----------|---------|
+| `S3_PROVIDER` | S3 provider (e.g. `Scaleway`, see rclone docs) | Yes |
+| `S3_ACCESS_KEY_ID` | S3 access key | Yes | - |
+| `S3_SECRET_ACCESS_KEY` | S3 secret key | Yes | - |
+| `S3_REGION` | S3 region | Yes | `nl-ams` |
+| `S3_ENDPOINT` | S3 endpoint URL | Yes | `s3.nl-ams.scw.cloud` |
+| `S3_BUCKET` | S3 bucket name | Yes | `my-backups` |
+| `S3_PATH` | Path prefix in bucket | Yes | `database/production` |
+| `S3_STORAGE_CLASS` | S3 storage class | No | Scaleway: `STANDARD`, `ONEZONE_IA`, `GLACIER` |
+
+### Webhook configuration
+
+A heartbeat url can be triggered when the job has been succesfully completed.
+If the environment variable is not configured, this step will be skipped.
+
+| Variable | Description | Required | Example |
+|----------|-------------|----------|---------|
+| `HEARTBEAT_URL` | Heartbeat webhook url | no | - |
+
+## Backup File Format
+
+Backups are stored with the following naming convention:
+
+```
+{DB_NAME}_{TIMESTAMP}.custom
+```
+
+Example: `production_20251226T01.custom`
+
+The `.custom` format is PostgreSQL's custom format, which can be restored using `pg_restore`.
+
+## Restoring Backups
+
+### PostgreSQL
+
+```bash
+# Restore to database
+pg_restore \
+  -h ip \
+  -p port \
+  -U user \
+  -d database \
+  --no-owner \
+  --no-privileges \
+  --single-transaction \
+  --exclude-schema=_timescaledb_internal \
+  --exclude-schema=_timescaledb_cache \
+  --exclude-schema=_timescaledb_catalog \
+  --exclude-schema=_timescaledb_config \
+  production_20251226T010203Z.custom
+```
+
+### MySQL/MariaDB
+
+For MySQL databases, the backup format may differ. Consult documentation for the exact format.
+
+## Error Handling & Heartbeat
+
+The script will exit with code 1 and provide error details if:
+
+- Backup creation fails
+- S3 upload fails
+- Any critical step encounters an error
+
+Backup cleanup run after a successful sync to avoid accumulating backups. If configured, a heartbeat webhook will be triggered.

--- a/database-backup/scripts/commands/backup.sh
+++ b/database-backup/scripts/commands/backup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+safe_exec /scripts/other/backup.sh

--- a/database-backup/scripts/other/backup.sh
+++ b/database-backup/scripts/other/backup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+. "${SCRIPT_DIR}/lib/_common.sh"
+. "${SCRIPT_DIR}/lib/rclone.sh"
+. "${SCRIPT_DIR}/lib/scw.sh"
+
+# Input validation
+require_env_vars DB_INSTANCE_ID DB_NAME DB_PROVIDER S3_BUCKET S3_PATH
+case "$DB_PROVIDER" in
+  scw) require_env_vars SCW_ACCESS_KEY SCW_SECRET_KEY SCW_DEFAULT_ORGANIZATION_ID SCW_DEFAULT_PROJECT_ID SCW_DEFAULT_REGION ;;
+  *) ;;
+esac
+
+# Constants
+readonly BACKUP_NAME_PREFIX="w_automated_"
+readonly BACKUP_NAME="${BACKUP_NAME_PREFIX}${DB_NAME}_$(date -u +%Y%m%dT%H)"
+readonly RCLONE_TARGET="s3-remote:${S3_BUCKET}/${S3_PATH}"
+
+#
+# === Main ===
+#
+
+case "$DB_PROVIDER" in
+  scw)
+    # Create (or fetch existing) backup
+    echo "Creating (or fetching) backup…"
+    if ! backup_id=$(scw_fetch_or_create_backup "$DB_INSTANCE_ID" "$DB_NAME" "$BACKUP_NAME"); then
+      echo "Failed to create backup: ${backup_id}" >&2
+      exit 1
+    fi
+    echo "Waiting for backup ${backup_id} to be ready…"
+    scw_wait_on_backup "$backup_id"
+
+    # Sync all pending backups (can be more than 1 if resuming)
+    echo "Syncing backups…"
+    sync_using_rclone() {
+      filename="${2#$BACKUP_NAME_PREFIX}.custom"
+      rclone_copy_url "$1" "${RCLONE_TARGET}/${filename}"
+    }
+    scw_sync_backups "$DB_INSTANCE_ID" "$BACKUP_NAME_PREFIX" sync_using_rclone
+    ;;
+  *)
+    echo "Unknown database provider ${DB_PROVIDER}" >&2
+    exit 1
+    ;;
+esac
+
+# Ping heartbeat webhook if configured and backup succeeded
+if [ -n "${HEARTBEAT_URL-}" ]; then
+  send_heartbeat "$HEARTBEAT_URL"
+fi

--- a/database-backup/scripts/other/lib/_common.sh
+++ b/database-backup/scripts/other/lib/_common.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Fail on first error
+set -eu
+
+# Verify tools installed
+if ! command -v curl >/dev/null 2>&1; then
+  echo >&2 'Error: curl is not installed.'
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo >&2 'Error: jq is not installed.'
+  exit 1
+fi
+
+#
+# === General Helper Functions ===
+#
+
+# Params:
+# List of ENV var names
+require_env_vars() {
+  for var in "$@"; do
+    eval "value=\${$var}"
+    [ -n "$value" ] || {
+      echo "Error: $var is required" >&2
+      exit 1
+    }
+  done
+}
+
+# Params:
+# - Heartbeat URL
+send_heartbeat() {
+  if curl -fsS --retry 3 "$1" > /dev/null 2>&1; then
+    echo "Heartbeat ping successful"
+  else
+    echo "Warning: Failed to send heartbeat ping to ${1}" >&2
+  fi
+}

--- a/database-backup/scripts/other/lib/rclone.sh
+++ b/database-backup/scripts/other/lib/rclone.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# Verify tools installed
+if ! command -v rclone >/dev/null 2>&1; then
+  echo >&2 'Error: rclone is not installed.' >&2
+  exit 1
+fi
+
+# Constants
+readonly RCLONE_CONCURRENCY=2
+readonly RCLONE_CHUNK_SIZE=16M
+readonly RCLONE_TIMEOUT=30s
+
+#
+# === RDB Backup Functions ===
+#
+
+# Params:
+# - Source
+# - Target
+rclone_copy_url() {
+  # Note: limit memory use by setting low concurrency & chunk size
+  rclone copyurl "$1" "$2" \
+    --low-level-retries 5 \
+    --no-check-certificate \
+    --progress \
+    --retries 2 \
+    --s3-chunk-size "$RCLONE_CHUNK_SIZE" \
+    --s3-upload-concurrency "$RCLONE_CONCURRENCY" \
+    --timeout 30s \
+    --transfers 1
+}

--- a/database-backup/scripts/other/lib/scw.sh
+++ b/database-backup/scripts/other/lib/scw.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+
+# Verify tools installed
+if ! command -v scw >/dev/null 2>&1; then
+  echo 'Error: scw is not installed.' >&2
+  exit 1
+fi
+
+# Constants
+readonly SCW_BACKUP_TIMEOUT=10m0s
+
+scw_cmd() {
+  scw --output=json $@
+}
+
+#
+# === RDB Backup Functions ===
+#
+
+# Params:
+# - Database Instance ID
+# - Database Name
+# - Backup name
+scw_fetch_or_create_backup() {
+  result=$(scw_cmd rdb backup list \
+    instance-id="$1" \
+    name="$3" 2>/dev/null \
+    | jq -r '.[0]?.ID // empty')
+
+  if [ -n "$result" ]; then
+    echo "${result}"
+  else
+    scw_cmd rdb backup create \
+      instance-id="$1" \
+      database-name="$2" \
+      name="$3" 2>&1 \
+      | jq -r '.id'
+  fi
+}
+
+# Params:
+# - Database Backup ID
+scw_wait_on_backup() {
+  scw_cmd rdb backup wait "$1" \
+    timeout="$SCW_BACKUP_TIMEOUT" > /dev/null
+}
+
+# Params:
+# - Database Instance ID
+# - Backup name (partial match, can be prefix)
+scw_get_ready_backups() {
+  scw_cmd rdb backup list \
+    instance-id="$1" \
+    name="$2" 2>/dev/null \
+    | jq -cr '.[] | select(.status? == "ready")'
+}
+
+# Params:
+# - Database Backup ID
+scw_export_backup() {
+  backup_status=
+
+  until [ "$backup_status" = 'ready' ]; do
+    result=$(scw_cmd rdb backup export "$1" 2>&1) || return 1
+    backup_status=$(printf '%s\n' "$result" | jq -r '.status')
+    [ "$backup_status" = 'ready' ] || sleep 1
+  done
+  
+  printf '%s\n' "$result" | jq -r '.download_url'
+}
+
+# Params:
+# - Database Backup ID
+scw_delete_backup() {
+  scw_cmd rdb backup delete "$1" >/dev/null 2>&1
+}
+
+# Params:
+# - Database Instance ID
+# - Backup name (partial match, can be prefix)
+# - Sync function/command that accepts an URL
+scw_sync_backups() {
+  sync_callback="$3"
+  scw_get_ready_backups "$1" "$2" | while read -r backup; do
+    backup_id=$(echo "$backup" | jq -r '.ID')
+    backup_name=$(echo "$backup" | jq -r '.name')
+    echo "Syncing backup ${backup_name} (${backup_id})…"
+
+    # Get export URL
+    if ! download_url=$(scw_export_backup "$backup_id"); then
+      echo "Failed to export backup ${backup_id}: ${download_url}" >&2
+      continue
+    fi
+
+    # Sync it
+    "$sync_callback" "$download_url" "$backup_name"
+
+    # Delete backup
+    scw_delete_backup "$backup_id"
+  done
+}

--- a/database-backup/scripts/startup/50-env-configure-rclone.sh
+++ b/database-backup/scripts/startup/50-env-configure-rclone.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+. "${SCRIPT_DIR}/../other/lib/_common.sh"
+
+# Configure rclone tool with a set of S3 credentials
+#
+# Inputs:
+# - S3_PROVIDER: S3 provider (see https://rclone.org/s3/)
+# - S3_ACCESS_KEY_ID: S3 access key
+# - S3_SECRET_ACCESS_KEY: S3 secret key
+# - S3_REGION: S3 region
+# - S3_ENDPOINT: S3 endpoint
+# - S3_STORAGE_CLASS: S3 storage class (see https://rclone.org/s3/#s3-storage-class)
+
+# Input validation
+require_env_vars S3_PROVIDER S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_REGION S3_ENDPOINT
+
+# Create configuration, will be used by later rclone invocations
+rclone config create s3-remote s3 \
+  provider "$S3_PROVIDER" \
+  access_key_id "$S3_ACCESS_KEY_ID" \
+  secret_access_key "$S3_SECRET_ACCESS_KEY" \
+  region "$S3_REGION" \
+  endpoint "$S3_ENDPOINT" \
+  acl private \
+  storage_class "$S3_STORAGE_CLASS" >/dev/null


### PR DESCRIPTION
See readme

I didn't check the build pipeline as it's already late, but will fix it when it fails.

Added `# hadolint ignore=DL3018` on `apk add` commands, as I saw it was used in other images as well, I can pin the version down, but I don't really see a need for it.

Spinners are optional (and generated), but I like me some visual flairs while waiting for a long backup, so I'm a fan 😅 