### PR TITLE
Silence monitoring access logs while keeping all other request logs.

### DIFF
--- a/common/config/nginx/nginx.conf
+++ b/common/config/nginx/nginx.conf
@@ -32,8 +32,8 @@ http {
   # Logging
   map $http_user_agent $loggable {
     default 1;
-    ~*^kube-probe/ 0;
-    ~*^Better Stack/ 0;
+    "~*^kube-probe/" 0;
+    "~*^Better Stack/" 0;
   }
   access_log /dev/stdout main if=$loggable;
   

--- a/common/config/nginx/nginx.conf
+++ b/common/config/nginx/nginx.conf
@@ -29,8 +29,15 @@ http {
   log_format main '$remote_addr "$request" $status $body_bytes_sent '
                   '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
 
+  # Logging
+  map $http_user_agent $loggable {
+    default 1;
+    ~*^kube-probe/ 0;
+    ~*^Better Stack/ 0;
+  }
+  access_log /dev/stdout main if=$loggable;
+  
   # Performance
-  access_log /dev/stdout main;
   tcp_nopush on;
   tcp_nodelay on;
   reset_timedout_connection on;

--- a/common/config/nginx/nginx.conf
+++ b/common/config/nginx/nginx.conf
@@ -29,7 +29,7 @@ http {
   log_format main '$remote_addr "$request" $status $body_bytes_sent '
                   '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
 
-  # Logging
+  # Disable logging for health probes
   map $http_user_agent $loggable {
     default 1;
     "~*^kube-probe/" 0;


### PR DESCRIPTION
To reduce load on our signoz cluster, I want to stop monitoring calls showing up in the access logs.
I used a Map so we can add other monitoring tools easily in the future.

`91.98.38.26 - - [16/Apr/2026:17:40:45 +0000] "GET / HTTP/2.0" 302 32 "-" "Better Stack Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36" 136 0.002 [shared-zitadel-shared-zitadel-service-http] [] 100.64.8.114:8080 41 0.002 302 616b17a7e4b19d76ca1161c962750221`

`100.64.0.210 "GET / HTTP/1.1" 200 1601 "-" "kube-probe/1.32" "-"`